### PR TITLE
feat: Add configurable base URL for OpenRouter API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# OpenRouter API Key - REQUIRED
+# Get your key from https://openrouter.ai/keys
+OPENROUTER_API_KEY=your-api-key-here
+
+# OpenRouter Base URL - Optional
+# The base URL for the OpenRouter API.
+# Defaults to https://openrouter.ai/api/v1
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
+# Default Model - Optional
+# The default model to use if not specified in the request.
+OPENROUTER_DEFAULT_MODEL=openrouter/auto
+
+# Default Max Tokens - Optional
+# Default maximum number of tokens to generate.
+OPENROUTER_MAX_TOKENS=1024
+
+# --- Provider Routing Defaults (Optional) ---
+
+# Default Quantizations - Optional
+# Comma-separated list of default quantization levels to filter by (e.g., "fp16,int8").
+OPENROUTER_PROVIDER_QUANTIZATIONS=
+
+# Default Ignored Providers - Optional
+# Comma-separated list of default provider names to ignore (e.g., "mistralai,openai").
+OPENROUTER_PROVIDER_IGNORE=
+
+# Default Provider Sort - Optional
+# Default sort order for providers ("price", "throughput", or "latency").
+OPENROUTER_PROVIDER_SORT=price
+
+# Default Provider Order - Optional
+# Default prioritized list of provider IDs (JSON array string).
+OPENROUTER_PROVIDER_ORDER='["openai/gpt-4o", "anthropic/claude-3-opus"]'
+
+# Default Provider Require Parameters - Optional
+# Default boolean ('true' or 'false') to only use providers supporting all request parameters.
+OPENROUTER_PROVIDER_REQUIRE_PARAMETERS=true
+
+# Default Provider Data Collection - Optional
+# Default data collection policy ("allow" or "deny").
+OPENROUTER_PROVIDER_DATA_COLLECTION=deny
+
+# Default Provider Allow Fallbacks - Optional
+# Default boolean ('true' or 'false') to control fallback behavior.
+OPENROUTER_PROVIDER_ALLOW_FALLBACKS=false

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # OpenRouter MCP Server
 
-[![MCP Server](https://img.shields.io/badge/MCP-Server-green)](https://github.com/heltonteixeira/openrouterai)
-[![Version](https://img.shields.io/badge/version-2.2.0-blue)](CHANGELOG.md)
+[![MCP Server](https://img.shields.io/badge/MCP-Server-green)](https://github.com/arbal/openrouterai)
+[![Version](https://img.shields.io/badge/version-2.2.1-blue)](CHANGELOG.md)
 [![TypeScript](https://img.shields.io/badge/language-TypeScript-blue)](https://www.typescriptlang.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen)](LICENSE)
 
 A Model Context Protocol (MCP) server providing seamless integration with OpenRouter.ai's diverse model ecosystem. Access various AI models through a unified, type-safe interface with built-in caching, rate limiting, and error handling.
 
-<a href="https://glama.ai/mcp/servers/xdnmf8yei0"><img width="380" height="200" src="https://glama.ai/mcp/servers/xdnmf8yei0/badge" alt="OpenRouter Server MCP server" /></a>
+## Fork Information
+
+This repository is a fork of [`heltonteixeira/openrouterai`](https://github.com/heltonteixeira/openrouterai). It includes the following modifications:
+
+*   **Configurable Base URL**: Added support for a custom OpenRouter API base URL via the `OPENROUTER_BASE_URL` environment variable.
+
+All original credit for the core functionality and design of this server goes to the original authors.
 
 ## Features
 
@@ -41,6 +47,7 @@ pnpm install @mcpservers/openrouterai
 ### Environment Variables
 
 *   `OPENROUTER_API_KEY`: **Required**. Your OpenRouter API key.
+*   `OPENROUTER_BASE_URL`: Optional. The base URL for the OpenRouter API. Defaults to `https://openrouter.ai/api/v1`.
 *   `OPENROUTER_DEFAULT_MODEL`: Optional. The default model to use if not specified in the request (e.g., `openrouter/auto`).
 *   `OPENROUTER_MAX_TOKENS`: Optional. Default maximum number of tokens to generate if `max_tokens` is not provided in the request.
 *   `OPENROUTER_PROVIDER_QUANTIZATIONS`: Optional. Comma-separated list of default quantization levels to filter by (e.g., `fp16,int8`) if `provider.quantizations` is not provided in the request. (Phase 1)
@@ -54,6 +61,7 @@ pnpm install @mcpservers/openrouterai
 ```env
 # Example .env file content
 OPENROUTER_API_KEY=your-api-key-here
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 OPENROUTER_DEFAULT_MODEL=openrouter/auto
 OPENROUTER_MAX_TOKENS=1024
 OPENROUTER_PROVIDER_QUANTIZATIONS=fp16,int8

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { ToolHandlers } from './tool-handlers.js';
 
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+const OPENROUTER_BASE_URL = process.env.OPENROUTER_BASE_URL;
 const DEFAULT_MODEL = process.env.OPENROUTER_DEFAULT_MODEL;
 const DEFAULT_MAX_TOKENS = process.env.OPENROUTER_MAX_TOKENS; // String | undefined
 const DEFAULT_QUANTIZATIONS = process.env.OPENROUTER_PROVIDER_QUANTIZATIONS?.split(',').map(q => q.trim()).filter(q => q) || undefined; // string[] | undefined
@@ -51,7 +52,8 @@ class OpenRouterServer {
       DEFAULT_PROVIDER_ORDER,
       DEFAULT_PROVIDER_REQUIRE_PARAMETERS,
       DEFAULT_PROVIDER_DATA_COLLECTION,
-      DEFAULT_PROVIDER_ALLOW_FALLBACKS
+      DEFAULT_PROVIDER_ALLOW_FALLBACKS,
+      OPENROUTER_BASE_URL
     );
     
     // Error handling

--- a/src/openrouter-api.ts
+++ b/src/openrouter-api.ts
@@ -18,13 +18,13 @@ export class OpenRouterAPIClient {
     total: 50
   };
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, baseURL: string = 'https://openrouter.ai/api/v1') {
     // Initialize axios instance for OpenRouter API
     this.axiosInstance = axios.create({
-      baseURL: 'https://openrouter.ai/api/v1',
+      baseURL: baseURL,
       headers: {
         'Authorization': `Bearer ${apiKey}`,
-        'HTTP-Referer': 'https://github.com/heltonteixeira/openrouterai',
+        'HTTP-Referer': 'https://github.com/arbal/openrouterai',
         'X-Title': 'MCP OpenRouter Server'
       }
     });

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -43,11 +43,12 @@ export class ToolHandlers {
     defaultProviderOrder?: string[],
     defaultProviderRequireParameters?: boolean,
     defaultProviderDataCollection?: "allow" | "deny",
-    defaultProviderAllowFallbacks?: boolean
+    defaultProviderAllowFallbacks?: boolean,
+    baseURL?: string
   ) {
     this.server = server;
     this.modelCache = ModelCache.getInstance();
-    this.apiClient = new OpenRouterAPIClient(apiKey);
+    this.apiClient = new OpenRouterAPIClient(apiKey, baseURL);
     this.defaultModel = defaultModel;
     this.defaultMaxTokens = defaultMaxTokens;
     this.defaultQuantizations = defaultQuantizations;
@@ -61,9 +62,9 @@ export class ToolHandlers {
 
     this.openai = new OpenAI({
       apiKey: apiKey,
-      baseURL: 'https://openrouter.ai/api/v1',
+      baseURL: baseURL || 'https://openrouter.ai/api/v1',
       defaultHeaders: {
-        'HTTP-Referer': 'https://github.com/heltonteixeira/openrouterai',
+        'HTTP-Referer': 'https://github.com/arbal/openrouterai',
         'X-Title': 'MCP OpenRouter Server',
       },
     });


### PR DESCRIPTION
This commit introduces a new environment variable, `OPENROUTER_BASE_URL`, allowing users to specify a custom base URL for the OpenRouter API.

- The API clients are updated to use this new variable, with a fallback to the default 'https://openrouter.ai/api/v1' for backward compatibility.
- All relevant files, including `src/index.ts`, `src/openrouter-api.ts`, and `src/tool-handlers.ts`, have been modified to support this feature.
- The `README.md` is updated to document the new environment variable and to reflect that this is a fork of the original repository.
- An `.env.example` file has been added for user convenience.